### PR TITLE
Optional auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ See the [Concourse docs](https://concourse-ci.org/resource-types.html) for more 
 
 * `url`: *Required.* Slack webhook URL.
 * `concourse_url`: *Optional.* The external URL that points to Concourse. Defaults to the env variable `ATC_EXTERNAL_URL`.
-* `username`: *Optional.* Concourse basic auth username. Required if using alert type `fixed`
-* `password`: *Optional.* Concourse basic auth password. Required if using alert type `fixed`
+* `username`: *Optional.* Concourse basic auth username. Required for non-public pipelines if using alert type `fixed`
+* `password`: *Optional.* Concourse basic auth password. Required for non-public pipelines if using alert type `fixed`
 
 ## Behavior
 

--- a/concourse/client.go
+++ b/concourse/client.go
@@ -38,6 +38,10 @@ func NewClient(username, password, host, team string) (*Client, error) {
 		team: team,
 	}
 
+	//Skip auth if no username and password provided
+	if username == "" && password == "" {
+		return c, nil
+	}
 	client := http.Client{}
 	authURL := c.host + fmt.Sprintf(apiAuth, c.team)
 	req, err := http.NewRequest("GET", authURL, nil)
@@ -67,11 +71,13 @@ func (c *Client) GetBuild(pipeline, job, name string) (*Build, error) {
 		return nil, err
 	}
 
-	cookie := &http.Cookie{
-		Name:  "ATC-Authorization",
-		Value: fmt.Sprintf("%s %s", c.auth.Type, c.auth.Value),
+	if c.auth.Type != "" {
+		cookie := &http.Cookie{
+			Name:  "ATC-Authorization",
+			Value: fmt.Sprintf("%s %s", c.auth.Type, c.auth.Value),
+		}
+		req.AddCookie(cookie)
 	}
-	req.AddCookie(cookie)
 
 	r, err := client.Do(req)
 	if err != nil {

--- a/out/main.go
+++ b/out/main.go
@@ -28,6 +28,9 @@ func main() {
 	}
 
 	o, err := out(input)
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	err = json.NewEncoder(os.Stdout).Encode(o)
 	if err != nil {

--- a/out/main.go
+++ b/out/main.go
@@ -139,10 +139,6 @@ func checkPreviousBuild(input *concourse.OutRequest, meta *concourse.BuildMetada
 		return false, nil
 	}
 
-	if input.Source.Username == "" || input.Source.Password == "" {
-		return false, errors.New("Source username and password cannot be blank if alert type is 'fixed'")
-	}
-
 	c, err := concourse.NewClient(input.Source.Username, input.Source.Password, meta.URL, meta.TeamName)
 	if err != nil {
 		return false, fmt.Errorf("error logging into Concourse: %s", err)


### PR DESCRIPTION
Thanks for this awesome resource!

We happen to have most of our pipelines set to "public" in that case authentication is not required to fetch the build status. This makes configuring this resource even easier and we reduce the risk of leaking concourse credentials by accident.