### PR TITLE
Make channel configurable on resource and step level

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See the [Concourse docs](https://concourse-ci.org/resource-types.html) for more 
 * `concourse_url`: *Optional.* The external URL that points to Concourse. Defaults to the env variable `ATC_EXTERNAL_URL`.
 * `username`: *Optional.* Concourse basic auth username. Required for non-public pipelines if using alert type `fixed`
 * `password`: *Optional.* Concourse basic auth password. Required for non-public pipelines if using alert type `fixed`
+* `channel`: *Optional*. Target channel where messages are posted. If unset the default channel of the webhook is used.
 
 ## Behavior
 
@@ -73,6 +74,7 @@ Sends a structured message to Slack based on the alert type.
 - `message`: *Optional.* The status message at the top of the alert. Defaults to name of alert type, except for default which is nothing.
 - `color`: *Optional.* The color of the notification bar as a hexadecimal. Defaults to the icon color of the alert type.
 - `disable`: *Optional.* Disables the alert. Defaults to `false`.
+- `channel`: *Optional.* Channel where this message is posted. If unspecified it falls back to the `channel` setting of the resource.
 
 ## Examples
 

--- a/concourse/resource.go
+++ b/concourse/resource.go
@@ -5,6 +5,7 @@ type Source struct {
 	Username     string `json:"username"`
 	Password     string `json:"password"`
 	ConcourseURL string `json:"concourse_url"`
+	Channel      string `json:"channel"`
 }
 
 type Metadata struct {
@@ -24,6 +25,7 @@ type OutParams struct {
 	Message   string `json:"message"`
 	Color     string `json:"color"`
 	Disable   bool   `json:"disable"`
+	Channel   string `json:"channel"`
 }
 
 type OutResponse struct {

--- a/out/main.go
+++ b/out/main.go
@@ -115,8 +115,12 @@ func out(input *concourse.OutRequest) (*concourse.OutResponse, error) {
 			return nil, err
 		}
 	}
+	channel := input.Params.Channel
+	if channel == "" {
+		channel = input.Source.Channel
+	}
 
-	payload := buildSlackMessage(input.Source.URL, alert, metadata)
+	payload := buildSlackMessage(input.Source.URL, channel, alert, metadata)
 	if sendMessage {
 		err := slack.Send(input.Source.URL, payload)
 		if err != nil {
@@ -171,7 +175,7 @@ const (
 	fallbackTemplate = "%s: %s/%s/%s"
 )
 
-func buildSlackMessage(url string, alert *Alert, m *concourse.BuildMetadata) *slack.Payload {
+func buildSlackMessage(url, channel string, alert *Alert, m *concourse.BuildMetadata) *slack.Payload {
 	buildURL := fmt.Sprintf(buildURLTemplate, m.URL, m.TeamName, m.PipelineName, m.JobName, m.BuildName)
 	attachment := slack.Attachment{
 		Fallback:   fmt.Sprintf("%s -- %s", fmt.Sprintf(fallbackTemplate, alert.Message, m.PipelineName, m.JobName, m.BuildName), buildURL),
@@ -193,5 +197,5 @@ func buildSlackMessage(url string, alert *Alert, m *concourse.BuildMetadata) *sl
 		},
 	}
 
-	return &slack.Payload{Attachments: []slack.Attachment{attachment}}
+	return &slack.Payload{Channel: channel, Attachments: []slack.Attachment{attachment}}
 }

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -9,6 +9,7 @@ import (
 
 type Payload struct {
 	Attachments []Attachment `json:"attachments"`
+	Channel     string       `json:"channel,omitempty"`
 }
 
 type Attachment struct {


### PR DESCRIPTION
We are posting to 30 different channels from our pipelines. Creating webhooks for every channel is unfeasible for us.
This PR allows to overwrite the target channel on a `resource` and `step` level allowing us to reuse a single webhook integration that has a nice icon and name in all our pipelines.