### PR TITLE
Add ability to disable at Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ See the [Concourse docs](https://concourse-ci.org/resource-types.html) for more 
 * `concourse_url`: *Optional.* The external URL that points to Concourse. Defaults to the env variable `ATC_EXTERNAL_URL`.
 * `username`: *Optional.* Concourse basic auth username. Required for non-public pipelines if using alert type `fixed`
 * `password`: *Optional.* Concourse basic auth password. Required for non-public pipelines if using alert type `fixed`
+* `disable`: *Optional.* Disables the resource (does not send notifications). Defaults to `false`.
 
 ## Behavior
 

--- a/concourse/resource.go
+++ b/concourse/resource.go
@@ -7,6 +7,7 @@ type Source struct {
 	Password     string `json:"password"`
 	ConcourseURL string `json:"concourse_url"`
 	Channel      string `json:"channel"`
+	Disable      bool   `json:"disable"`
 }
 
 // Metadata are a key-value pair that must be included for in the in and out

--- a/out/alert.go
+++ b/out/alert.go
@@ -68,6 +68,9 @@ func NewAlert(input *concourse.OutRequest) Alert {
 	}
 
 	alert.Disabled = input.Params.Disable
+	if alert.Disabled == false {
+		alert.Disabled = input.Source.Disable
+	}
 	alert.Channel = input.Params.Channel
 	if alert.Channel == "" {
 		alert.Channel = input.Source.Channel

--- a/out/alert_test.go
+++ b/out/alert_test.go
@@ -26,9 +26,9 @@ func TestNewAlert(t *testing.T) {
 		},
 		"custom source": {
 			input: &concourse.OutRequest{
-				Source: concourse.Source{Channel: "general"},
+				Source: concourse.Source{Channel: "general", Disable: true},
 			},
-			want: Alert{Type: "default", Channel: "general", Color: "#35495c", IconURL: "https://ci.concourse-ci.org/public/images/favicon-pending.png"},
+			want: Alert{Type: "default", Channel: "general", Color: "#35495c", IconURL: "https://ci.concourse-ci.org/public/images/favicon-pending.png", Disabled: true},
 		},
 
 		// Alert types.


### PR DESCRIPTION
Disable at Source will prevent the resource from making any webhook
requests to slack if `Disable: true`.

Closes #15