### PR TITLE
Update Golang to 1.11, Alpine to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: go
 
 go:
-  - "1.10"
+  - "1.11"
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build
+FROM golang:1.11-alpine AS build
 
 ENV CGO_ENABLED 0
 RUN mkdir -p /go/src/github.com/arbourd/concourse-slack-alert-resource
@@ -9,7 +9,7 @@ RUN go build -o /check github.com/arbourd/concourse-slack-alert-resource/check
 RUN go build -o /in github.com/arbourd/concourse-slack-alert-resource/in
 RUN go build -o /out github.com/arbourd/concourse-slack-alert-resource/out
 
-FROM alpine:3.7
+FROM alpine:3.8
 RUN apk add --no-cache ca-certificates
 
 COPY --from=build /check /opt/resource/check


### PR DESCRIPTION
Image for Golang 1.11 has not been released yet.