### PR TITLE
url encode path parameters

### DIFF
--- a/concourse/build.go
+++ b/concourse/build.go
@@ -2,6 +2,7 @@ package concourse
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -33,13 +34,13 @@ type BuildMetadata struct {
 
 // NewBuildMetadata returns a populated BuildMetadata.
 // The default external URL can be overriden by the URL.
-func NewBuildMetadata(url string) BuildMetadata {
-	if url == "" {
-		url = os.Getenv("ATC_EXTERNAL_URL")
+func NewBuildMetadata(atcurl string) BuildMetadata {
+	if atcurl == "" {
+		atcurl = os.Getenv("ATC_EXTERNAL_URL")
 	}
 
 	metadata := BuildMetadata{
-		Host:         strings.TrimSuffix(url, "/"),
+		Host:         strings.TrimSuffix(atcurl, "/"),
 		ID:           os.Getenv("BUILD_ID"),
 		TeamName:     os.Getenv("BUILD_TEAM_NAME"),
 		PipelineName: os.Getenv("BUILD_PIPELINE_NAME"),
@@ -51,10 +52,10 @@ func NewBuildMetadata(url string) BuildMetadata {
 	metadata.URL = fmt.Sprintf(
 		"%s/teams/%s/pipelines/%s/jobs/%s/builds/%s",
 		metadata.Host,
-		metadata.TeamName,
-		metadata.PipelineName,
-		metadata.JobName,
-		metadata.BuildName,
+		url.PathEscape(metadata.TeamName),
+		url.PathEscape(metadata.PipelineName),
+		url.PathEscape(metadata.JobName),
+		url.PathEscape(metadata.BuildName),
 	)
 
 	return metadata

--- a/concourse/build_test.go
+++ b/concourse/build_test.go
@@ -11,7 +11,7 @@ func TestNewBuildMetadata(t *testing.T) {
 		"ATC_EXTERNAL_URL":    "https://ci.example.com",
 		"BUILD_TEAM_NAME":     "main",
 		"BUILD_PIPELINE_NAME": "demo",
-		"BUILD_JOB_NAME":      "test",
+		"BUILD_JOB_NAME":      "my test",
 		"BUILD_NAME":          "1",
 	}
 
@@ -24,9 +24,9 @@ func TestNewBuildMetadata(t *testing.T) {
 				Host:         "https://ci.example.com",
 				TeamName:     "main",
 				PipelineName: "demo",
-				JobName:      "test",
+				JobName:      "my test",
 				BuildName:    "1",
-				URL:          "https://ci.example.com/teams/main/pipelines/demo/jobs/test/builds/1",
+				URL:          "https://ci.example.com/teams/main/pipelines/demo/jobs/my%20test/builds/1",
 			},
 		},
 		"url override": {
@@ -35,9 +35,9 @@ func TestNewBuildMetadata(t *testing.T) {
 				Host:         "https://example.com",
 				TeamName:     "main",
 				PipelineName: "demo",
-				JobName:      "test",
+				JobName:      "my test",
 				BuildName:    "1",
-				URL:          "https://example.com/teams/main/pipelines/demo/jobs/test/builds/1",
+				URL:          "https://example.com/teams/main/pipelines/demo/jobs/my%20test/builds/1",
 			},
 		},
 	}


### PR DESCRIPTION
URL encode path parameters when building URL to build to allow jobs, pipeline or team to have spaces or special characters