### PR TITLE
Add webhook url to public part of the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: go
 go:
   - "1.12"
 
+env:
+  - SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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
+
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
This makes it work for non-arbourd pull-requests. It's not much of a
secret anyways