### PR TITLE
fix: cookie name for login in versions bigger than 5.5.0

### DIFF
--- a/concourse/client.go
+++ b/concourse/client.go
@@ -77,13 +77,13 @@ func NewClient(atcurl, team, username, password string) (*Client, error) {
 	// Check if target Concourse is less than '4.0.0'.
 	if s.Check(v) {
 		err = c.loginLegacy(username, password)
-	// Check if the version is less than '5.5.0'.
 	} else {
 		t, err := c.login(username, password)
 		if err != nil {
 			return nil, err
 		}
-
+		
+		// Check if the version is less than '5.5.0'.
 		if up.Check(v) {
 			err = c.singleCookie(t)
 		} else {

--- a/concourse/client.go
+++ b/concourse/client.go
@@ -161,7 +161,7 @@ func (c *Client) splitToken(t *oauth2.Token) error {
 }
 
 // login gets an access token from Concourse.
-func (c *Client) login(username string, password string) (*oauth2.Token, error) {
+func (c *Client) login(username, password string) (*oauth2.Token, error) {
 	u := fmt.Sprintf("%s/sky/token", c.atcurl)
 	config := oauth2.Config{
 		ClientID:     "fly",

--- a/concourse/client.go
+++ b/concourse/client.go
@@ -118,7 +118,7 @@ func (c *Client) login(username, password string) error {
 	c.conn.Jar.SetCookies(
 		c.atcurl,
 		[]*http.Cookie{{
-			Name:  "skymarshal_auth",
+			Name:  "skymarshal_auth0",
 			Value: fmt.Sprintf("%s %s", t.TokenType, t.AccessToken),
 		}},
 	)


### PR DESCRIPTION
In the new versions of concourse they use a naming convention for their cookies like skymarshal_auth{number}

https://github.com/concourse/concourse/blob/master/skymarshal/token/middleware.go