### PR TITLE
Add 6.5.0 support

### DIFF
--- a/concourse/client.go
+++ b/concourse/client.go
@@ -70,7 +70,7 @@ func NewClient(atcurl, team, username, password string) (*Client, error) {
 		return nil, err
 	}
 
-	cookie, err := semver.NewConstraint("< 5.5.0")
+	multiCookie, err := semver.NewConstraint("5.5 - 6.4")
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,9 @@ func NewClient(atcurl, team, username, password string) (*Client, error) {
 		return nil, err
 	}
 
-	// Check if the version is less than '5.5.0'.
-	if cookie.Check(v) {
+	// Check if the version supports single cookie access tokens.
+	// Single cookie is used between versions 4.0.0 - 5.5.0 and 6.5.0 or greater.
+	if !multiCookie.Check(v) {
 		err = c.singleCookie(token.TokenType, token.AccessToken)
 		return c, err
 	}

--- a/concourse/client_test.go
+++ b/concourse/client_test.go
@@ -24,7 +24,7 @@ func TestNewClient(t *testing.T) {
 		err     bool
 	}{
 		"public": {
-			version: "6.0.0",
+			version: "6.5.0",
 			public:  true,
 		},
 		"legacy auth": {
@@ -48,13 +48,20 @@ func TestNewClient(t *testing.T) {
 
 			token: "multi-cookie",
 		},
-		"skymarshal": {
+		"skymarshal id token": {
 			version:  "6.0.0",
 			username: "admin",
 			password: "sup3rs3cret1",
 
 			token:   "new-access-token",
 			idToken: "id-token",
+		},
+		"skymarshal access token": {
+			version:  "6.5.0",
+			username: "admin",
+			password: "sup3rs3cret1",
+
+			token: "new-access-token",
 		},
 		"missing id token": {
 			version:  "6.0.0",
@@ -65,7 +72,7 @@ func TestNewClient(t *testing.T) {
 			err:   true,
 		},
 		"unauthorized": {
-			version:  "6.0.0",
+			version:  "6.5.0",
 			username: "admin",
 			password: "sup3rs3cret1",
 


### PR DESCRIPTION
Concourse has moved back to a single cookie authentication pattern with
6.5.0. This commit allows 6.5.0 and up to use the same auth flow as
4.0-5.5.

Closes #65