### PR TITLE
Add text field to Slack Alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Sends a structured message to Slack based on the alert type.
 - `channel_file`: *Optional.* File containing text which overrides `channel`. If the file cannot be read, `channel` will be used instead.
 - `message`: *Optional.* The status message at the top of the alert. Defaults to name of alert type.
 - `message_file`: *Optional.* File containing text which overrides `message`. If the file cannot be read, `message` will be used instead.
+- `text`: *Optional.* The status text at the top of the alert. Defaults to name of alert type.
+- `text_file`: *Optional.* File containing text which overrides `text`. If the file cannot be read, `text` will be used instead.
 - `color`: *Optional.* The color of the notification bar as a hexadecimal. Defaults to the icon color of the alert type.
 - `disable`: *Optional.* Disables the alert. Defaults to `false`.
 

--- a/concourse/resource.go
+++ b/concourse/resource.go
@@ -37,6 +37,8 @@ type OutParams struct {
 	Color       string `json:"color"`
 	Message     string `json:"message"`
 	MessageFile string `json:"message_file"`
+	Text        string `json:"text"`
+	TextFile    string `json:"text_file"`
 	Disable     bool   `json:"disable"`
 }
 

--- a/out/alert.go
+++ b/out/alert.go
@@ -11,6 +11,8 @@ type Alert struct {
 	IconURL     string
 	Message     string
 	MessageFile string
+	Text        string
+	TextFile    string
 	Disabled    bool
 }
 
@@ -73,17 +75,23 @@ func NewAlert(input *concourse.OutRequest) Alert {
 	if alert.Disabled == false {
 		alert.Disabled = input.Source.Disable
 	}
+
 	alert.Channel = input.Params.Channel
 	if alert.Channel == "" {
 		alert.Channel = input.Source.Channel
 	}
+	alert.ChannelFile = input.Params.ChannelFile
+
 	if input.Params.Message != "" {
 		alert.Message = input.Params.Message
 	}
+	alert.MessageFile = input.Params.MessageFile
+
 	if input.Params.Color != "" {
 		alert.Color = input.Params.Color
 	}
-	alert.MessageFile = input.Params.MessageFile
-	alert.ChannelFile = input.Params.ChannelFile
+
+	alert.Text = input.Params.Text
+	alert.TextFile = input.Params.TextFile
 	return alert
 }

--- a/out/alert_test.go
+++ b/out/alert_test.go
@@ -20,9 +20,9 @@ func TestNewAlert(t *testing.T) {
 		"custom params": {
 			input: &concourse.OutRequest{
 				Source: concourse.Source{Channel: "general"},
-				Params: concourse.OutParams{Channel: "custom-channel", Color: "#ffffff", Message: "custom-message", Disable: true},
+				Params: concourse.OutParams{Channel: "custom-channel", Color: "#ffffff", Message: "custom-message", Text: "custom-text", Disable: true},
 			},
-			want: Alert{Type: "default", Channel: "custom-channel", Color: "#ffffff", IconURL: "https://ci.concourse-ci.org/public/images/favicon-pending.png", Message: "custom-message", Disabled: true},
+			want: Alert{Type: "default", Channel: "custom-channel", Color: "#ffffff", IconURL: "https://ci.concourse-ci.org/public/images/favicon-pending.png", Message: "custom-message", Text: "custom-text", Disabled: true},
 		},
 		"custom source": {
 			input: &concourse.OutRequest{

--- a/out/main.go
+++ b/out/main.go
@@ -18,6 +18,7 @@ import (
 func buildMessage(alert Alert, m concourse.BuildMetadata, path string) *slack.Message {
 	message := alert.Message
 	channel := alert.Channel
+	text := alert.Text
 
 	// Open and read message file if set
 	if alert.MessageFile != "" {
@@ -43,6 +44,18 @@ func buildMessage(alert Alert, m concourse.BuildMetadata, path string) *slack.Me
 		}
 	}
 
+	// Open and read text file if set
+	if alert.TextFile != "" {
+		file := filepath.Join(path, alert.TextFile)
+		f, err := ioutil.ReadFile(file)
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading text_file: %v\nwill default to text instead\n", err)
+		} else {
+			text = strings.TrimSpace(string(f))
+		}
+	}
+
 	attachment := slack.Attachment{
 		Fallback:   fmt.Sprintf("%s -- %s", fmt.Sprintf("%s: %s/%s/%s", message, m.PipelineName, m.JobName, m.BuildName), m.URL),
 		AuthorName: message,
@@ -61,6 +74,7 @@ func buildMessage(alert Alert, m concourse.BuildMetadata, path string) *slack.Me
 				Short: true,
 			},
 		},
+		Text: text,
 	}
 
 	return &slack.Message{Attachments: []slack.Attachment{attachment}, Channel: channel}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -23,6 +23,7 @@ type Attachment struct {
 	Fields     []Field `json:"fields"`
 	Footer     string  `json:"footer"`
 	FooterIcon string  `json:"footer_icon"`
+	Text       string  `json:"text"`
 }
 
 // Field represents a Slack API message attachment's fields


### PR DESCRIPTION
Adds the parameter `text` to the Slack alert resource.

`text` sits right below the message in the alert body and is an empty string by default. This field can be used to pass in additional information about the alert status (without replacing the header). It can also be used to [mention users](https://api.slack.com/reference/surfaces/formatting#mentioning-users).

Closes #43 