### PR TITLE
Fix 6.0 SkyMarshall calls

### DIFF
--- a/concourse/client.go
+++ b/concourse/client.go
@@ -75,7 +75,7 @@ func NewClient(atcurl, team, username, password string) (*Client, error) {
 		return nil, err
 	}
 
-	oldsky, err := semver.NewConstraint("< 6.0.0")
+	oldsky, err := semver.NewConstraint("< 6.1.0")
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func NewClient(atcurl, team, username, password string) (*Client, error) {
 		return c, err
 	}
 
-	// Check if the version is less than '6.0.0'.
+	// Check if the version is less than '6.1.0'.
 	if oldsky.Check(v) {
 		err = c.splitToken(token.TokenType, token.AccessToken)
 		return c, err

--- a/concourse/client_test.go
+++ b/concourse/client_test.go
@@ -42,14 +42,14 @@ func TestNewClient(t *testing.T) {
 			token: "access-token",
 		},
 		"multi cookie": {
-			version:  "5.5.0",
+			version:  "6.0.0",
 			username: "admin",
 			password: "sup3rs3cret1",
 
 			token: "multi-cookie",
 		},
 		"skymarshal id token": {
-			version:  "6.0.0",
+			version:  "6.1.0",
 			username: "admin",
 			password: "sup3rs3cret1",
 
@@ -64,7 +64,7 @@ func TestNewClient(t *testing.T) {
 			token: "new-access-token",
 		},
 		"missing id token": {
-			version:  "6.0.0",
+			version:  "6.1.0",
 			username: "admin",
 			password: "sup3rs3cret1",
 


### PR DESCRIPTION
v0.11.0 was supposed to fix auth changes in 6.0.0, but those changes
actually came in 6.1.0. 6.0.0 actually retains auth (for `fly`) similar
to the later 5.x releases.

Fixes #70 