### PR TITLE
Add `errored` alert type

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Sends a structured message to Slack based on the alert type.
 
   <img src="./img/aborted.png" width="50%">
 
+- `errored`
+
+  <img src="./img/errored.png" width="50%">
+
 - `fixed`
 
   Fixed is a special alert type that only alerts if the previous build did not succeed. Fixed requires `username` and `password` to be set for the resource if the pipeline is not public.
@@ -138,6 +142,10 @@ jobs:
       put: notify
       params:
         alert_type: aborted
+    on_error:
+      put: notify
+      params:
+        alert_type: errored
 ```
 
 Using the `fixed` alert type:

--- a/out/alert.go
+++ b/out/alert.go
@@ -62,6 +62,13 @@ func NewAlert(input *concourse.OutRequest) Alert {
 			IconURL: "https://ci.concourse-ci.org/public/images/favicon-failed.png",
 			Message: "Broke",
 		}
+	case "errored":
+		alert = Alert{
+			Type:    "errored",
+			Color:   "#f5a623",
+			IconURL: "https://ci.concourse-ci.org/public/images/favicon-errored.png",
+			Message: "Errored",
+		}
 	default:
 		alert = Alert{
 			Type:    "default",

--- a/out/alert_test.go
+++ b/out/alert_test.go
@@ -56,6 +56,10 @@ func TestNewAlert(t *testing.T) {
 			input: &concourse.OutRequest{Params: concourse.OutParams{AlertType: "broke"}},
 			want:  Alert{Type: "broke", Color: "#d00000", IconURL: "https://ci.concourse-ci.org/public/images/favicon-failed.png", Message: "Broke"},
 		},
+		"errored": {
+			input: &concourse.OutRequest{Params: concourse.OutParams{AlertType: "errored"}},
+			want:  Alert{Type: "errored", Color: "#f5a623", IconURL: "https://ci.concourse-ci.org/public/images/favicon-errored.png", Message: "Errored"},
+		},
 	}
 
 	for name, c := range cases {


### PR DESCRIPTION
Colour was picked by inspecting the build header colour in my browser
which was `background: rgb(245, 166, 35);` and converting that to
hexadecimal.

Note, there is no image for the readme included as part of this commit
as I'm not too sure how to generate it to look consistent with the
others. I would appreciate help generating the equivalent image for this
please.