### PR TITLE
README: fix broken resource metadata link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A structured and opinionated Slack notification resource for [Concourse](https:/
 
 <img src="./img/default.png" width="60%">
 
-The message is built by using Concourse's [resource metadata](https://concourse-ci.org/implementing-resources.html#resource-metadata) to show the pipeline, job, build number and a URL.
+The message is built by using Concourse's [resource metadata](https://concourse-ci.org/implementing-resource-types.html#resource-metadata) to show the pipeline, job, build number and a URL.
 
 ## Installing
 


### PR DESCRIPTION
The link is broken, fix it by adding the new link.

Signed-off-by: Mattijs Korpershoek <mattijs.korpershoek@gmail.com>