### PR TITLE
Instanced Pipelines support Alert types `fixed` and `broke`

### DIFF
--- a/concourse/build.go
+++ b/concourse/build.go
@@ -10,15 +10,16 @@ import (
 
 // A Build is a build's data from the undocumented Concourse API.
 type Build struct {
-	ID        int    `json:"id"`
-	Team      string `json:"team_name"`
-	Name      string `json:"name"`
-	Status    string `json:"status"`
-	Job       string `json:"job_name"`
-	APIURL    string `json:"api_url"`
-	Pipeline  string `json:"pipeline_name"`
-	StartTime int    `json:"start_time"`
-	EndTime   int    `json:"end_time"`
+	ID           int               `json:"id"`
+	Team         string            `json:"team_name"`
+	Name         string            `json:"name"`
+	Status       string            `json:"status"`
+	Job          string            `json:"job_name"`
+	APIURL       string            `json:"api_url"`
+	Pipeline     string            `json:"pipeline_name"`
+	InstanceVars map[string]string `json:"pipeline_instance_vars,omitempty"`
+	StartTime    int               `json:"start_time"`
+	EndTime      int               `json:"end_time"`
 }
 
 // BuildMetadata is the current build's metadata exposed via the environment.

--- a/concourse/client.go
+++ b/concourse/client.go
@@ -226,14 +226,15 @@ func (c *Client) loginLegacy(url, username, password string) error {
 
 // JobBuild finds and returns a Build from the Concourse API by its
 // pipeline name, job name and build name.
-func (c *Client) JobBuild(pipeline, job, name string) (*Build, error) {
+func (c *Client) JobBuild(pipeline, job, name, instanceVars string) (*Build, error) {
 	u := fmt.Sprintf(
-		"%s/api/v1/teams/%s/pipelines/%s/jobs/%s/builds/%s",
+		"%s/api/v1/teams/%s/pipelines/%s/jobs/%s/builds/%s%s",
 		c.atcurl,
 		c.team,
 		pipeline,
 		job,
 		name,
+		instanceVars,
 	)
 
 	r, err := c.conn.Get(u)

--- a/out/main.go
+++ b/out/main.go
@@ -96,7 +96,13 @@ func previousBuildStatus(input *concourse.OutRequest, m concourse.BuildMetadata)
 		return "", fmt.Errorf("error parsing build name: %s", err)
 	}
 
-	previous, err := c.JobBuild(m.PipelineName, m.JobName, p)
+	instanceVars := ""
+	instanceVarsIndex := strings.Index(m.URL, "?")
+	if instanceVarsIndex > -1 {
+		instanceVars = m.URL[instanceVarsIndex:]
+	}
+
+	previous, err := c.JobBuild(m.PipelineName, m.JobName, p, instanceVars)
 	if err != nil {
 		return "", fmt.Errorf("error requesting Concourse build status: %s", err)
 	}


### PR DESCRIPTION
fixes https://github.com/arbourd/concourse-slack-alert-resource/issues/80 
uses https://github.com/arbourd/concourse-slack-alert-resource/pull/86

![image](https://user-images.githubusercontent.com/196165/195555136-0abc29a5-9b3b-4abc-b127-531496ddc01a.png)