### PR TITLE
Use JSON for vars instead of query params

### DIFF
--- a/concourse/build_test.go
+++ b/concourse/build_test.go
@@ -2,8 +2,9 @@ package concourse
 
 import (
 	"os"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewBuildMetadata(t *testing.T) {
@@ -44,15 +45,15 @@ func TestNewBuildMetadata(t *testing.T) {
 			},
 		},
 		"url with instance vars": {
-			instanceVars: `{"image_name":"my-image","pr_number":1234}`,
+			instanceVars: `{"image_name":"my-image","pr_number":1234,"args":["start"]}`,
 			want: BuildMetadata{
 				Host:         "https://ci.example.com",
 				TeamName:     "main",
 				PipelineName: "demo",
-				InstanceVars: `{"image_name":"my-image","pr_number":1234}`,
+				InstanceVars: `{"image_name":"my-image","pr_number":1234,"args":["start"]}`,
 				JobName:      "my test",
 				BuildName:    "1",
-				URL:          `https://ci.example.com/teams/main/pipelines/demo/jobs/my%20test/builds/1?vars.image_name=%22my-image%22&vars.pr_number=1234`,
+				URL:          `https://ci.example.com/teams/main/pipelines/demo/jobs/my%20test/builds/1?vars=%7B%22image_name%22%3A%22my-image%22%2C%22pr_number%22%3A1234%2C%22args%22%3A%5B%22start%22%5D%7D`,
 			},
 		},
 	}
@@ -69,8 +70,8 @@ func TestNewBuildMetadata(t *testing.T) {
 			}
 
 			metadata := NewBuildMetadata(c.host)
-			if !reflect.DeepEqual(metadata, c.want) {
-				t.Fatalf("unexpected BuildMetadata value from GetBuildMetadata:\n\t(GOT): %#v\n\t(WNT): %#v", metadata, c.want)
+			if !cmp.Equal(metadata, c.want) {
+				t.Fatalf("unexpected BuildMetadata value from GetBuildMetadata:\n\t(GOT): %#v\n\t(WNT): %#v\n\t(DIFF): %v", metadata, c.want, cmp.Diff(metadata, c.want))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/google/go-cmp v0.5.9
 	golang.org/x/oauth2 v0.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=

--- a/out/alert_test.go
+++ b/out/alert_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/arbourd/concourse-slack-alert-resource/concourse"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewAlert(t *testing.T) {
@@ -65,8 +65,8 @@ func TestNewAlert(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := NewAlert(c.input)
-			if !reflect.DeepEqual(got, c.want) {
-				t.Fatalf("unexpected Alert from NewAlert:\n\t(GOT): %#v\n\t(WNT): %#v", got, c.want)
+			if !cmp.Equal(got, c.want) {
+				t.Fatalf("unexpected Alert from NewAlert:\n\t(GOT): %#v\n\t(WNT): %#v\n\t(DIFF): %v", got, c.want, cmp.Diff(got, c.want))
 			}
 		})
 	}

--- a/out/main_test.go
+++ b/out/main_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/arbourd/concourse-slack-alert-resource/concourse"
 	"github.com/arbourd/concourse-slack-alert-resource/slack"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestOut(t *testing.T) {
@@ -209,8 +209,8 @@ func TestOut(t *testing.T) {
 				t.Fatalf("unexpected error from out:\n\t(ERR): %s", err)
 			} else if err == nil && c.err {
 				t.Fatalf("expected an error from out:\n\t(GOT): nil")
-			} else if !reflect.DeepEqual(got, c.want) {
-				t.Fatalf("unexpected concourse.OutResponse value from out:\n\t(GOT): %#v\n\t(WNT): %#v", got, c.want)
+			} else if !cmp.Equal(got, c.want) {
+				t.Fatalf("unexpected concourse.OutResponse value from out:\n\t(GOT): %#v\n\t(WNT): %#v\n\t(DIFF): %v", got, c.want, cmp.Diff(got, c.want))
 			}
 		})
 	}
@@ -367,8 +367,8 @@ func TestBuildMessage(t *testing.T) {
 			}
 
 			got := buildMessage(c.alert, metadata, path)
-			if !reflect.DeepEqual(got, c.want) {
-				t.Fatalf("unexpected slack.Message value from buildSlackMessage:\n\t(GOT): %#v\n\t(WNT): %#v", got, c.want)
+			if !cmp.Equal(got, c.want) {
+				t.Fatalf("unexpected slack.Message value from buildSlackMessage:\n\t(GOT): %#v\n\t(WNT): %#v\n\t(DIFF): %v", got, c.want, cmp.Diff(got, c.want))
 			}
 		})
 	}


### PR DESCRIPTION
This resource used a chain of query params that looked like `vars.key="value"`, that were originally sourced from JSON. We can also pass vars in as `?vars={"key":"value"}` with a JSON string directly, without having to parse the JSON and then reconstruct.

This means, we easily allow nested JSON, arrays or any other type we are currently not handling by just passing the JSON string from the Concourse itself and feeding it back into the URL.

Closes #105
