### PR TITLE
Add exponential backoff for Slack requests

### DIFF
--- a/check/main.go
+++ b/check/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 
@@ -11,6 +12,6 @@ import (
 func main() {
 	err := json.NewEncoder(os.Stdout).Encode(concourse.CheckResponse{})
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalln(fmt.Errorf("error: %s", err))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/google/go-cmp v0.6.0
 	golang.org/x/oauth2 v0.19.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/oauth2 v0.19.0 h1:9+E/EZBCbTLNrbN35fHv/a/d/mOBatymz1zbtQrXpIg=

--- a/in/main.go
+++ b/in/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 
@@ -11,6 +12,6 @@ import (
 func main() {
 	err := json.NewEncoder(os.Stdout).Encode(concourse.InResponse{Version: concourse.Version{"ver": "static"}})
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalln(fmt.Errorf("error: %s", err))
 	}
 }

--- a/out/main.go
+++ b/out/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/arbourd/concourse-slack-alert-resource/concourse"
 	"github.com/arbourd/concourse-slack-alert-resource/slack"
@@ -130,6 +131,8 @@ func previousBuildName(s string) (string, error) {
 	return strings.Trim(s, ".0"), nil
 }
 
+var maxElapsedTime = 30 * time.Second
+
 func out(input *concourse.OutRequest, path string) (*concourse.OutResponse, error) {
 	if input.Source.URL == "" {
 		return nil, errors.New("slack webhook url cannot be blank")
@@ -153,7 +156,7 @@ func out(input *concourse.OutRequest, path string) (*concourse.OutResponse, erro
 	}
 
 	message := buildMessage(alert, metadata, path)
-	err := slack.Send(input.Source.URL, message)
+	err := slack.Send(input.Source.URL, message, maxElapsedTime)
 	if err != nil {
 		return nil, fmt.Errorf("error sending slack message: %v", err)
 	}

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -4,37 +4,48 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestSend(t *testing.T) {
 	cases := map[string]struct {
 		message *Message
-		err     bool
+		backoff uint8
+		wantErr bool
 	}{
 		"ok": {
 			message: &Message{Channel: "concourse"},
+			backoff: 0,
 		},
-		"unauthorized": {
-			message: &Message{},
-			err:     true,
+		"retry ok": {
+			message: &Message{Channel: "concourse"},
+			backoff: 1,
+		},
+		"retry fail": {
+			message: &Message{Channel: "concourse"},
+			backoff: 255,
+			wantErr: true,
 		},
 	}
 
 	for name, c := range cases {
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if c.err {
-				http.Error(w, "", http.StatusUnauthorized)
-			}
-		}))
-
 		t.Run(name, func(t *testing.T) {
-			err := Send(s.URL, c.message)
-			if err != nil && !c.err {
+			tries := c.backoff
+
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tries > 0 {
+					tries--
+					http.Error(w, "", http.StatusUnauthorized)
+				}
+			}))
+			defer s.Close()
+
+			err := Send(s.URL, c.message, 2*time.Second)
+			if err != nil && !c.wantErr {
 				t.Fatalf("unexpected error from Send:\n\t(ERR): %s", err)
-			} else if err == nil && c.err {
+			} else if err == nil && c.wantErr {
 				t.Fatalf("expected an error from Send:\n\t(GOT): nil")
 			}
 		})
-		s.Close()
 	}
 }


### PR DESCRIPTION
Adds a 30 second retry to POST requests made to Slack's API, in the event that Slack experiences an intermittent failure.

Closes #94 

This does not retry locally on http requests to Concourse itself (for build data, `fixed`/`broke` type). Not sure if we'd want to add that there as well, perhaps with a shorter back off?